### PR TITLE
Update getAuctionsSchema.js

### DIFF
--- a/auction-service/src/lib/schemas/getAuctionsSchema.js
+++ b/auction-service/src/lib/schemas/getAuctionsSchema.js
@@ -1,4 +1,5 @@
 const schema = {
+    type: 'object',
     properties: {
       queryStringParameters: {
         type: 'object',


### PR DESCRIPTION
using"@middy/validator": "^2.5.1"
did not worked without type : 'object' at root of schema , it is given official documentation so i have applied and it worked .
with out type : 'object' at root getting this error "strict mode: missing type \"object\" for keyword \"required\" at \"#\" (strictTypes)"